### PR TITLE
fix: support virtio disk serial format in device lookup

### DIFF
--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -336,7 +336,7 @@ func (d *Driver) NodeGetInfo(ctx context.Context, request *csi.NodeGetInfoReques
 
 func findDeviceBySerial(serial string) (string, error) {
 	var bestMatch string
-	regex := regexp.MustCompile("QEMU_HARDDISK_([0-9a-f\\-]+)")
+	regex := regexp.MustCompile("(?:QEMU_HARDDISK[-_]|virtio-)([0-9a-f][-0-9a-f]*)")
 
 	err := filepath.Walk("/dev/disk/by-id", func(path string, info os.FileInfo, err error) error {
 		matches := regex.FindStringSubmatch(path)


### PR DESCRIPTION
## Problem

The `findDeviceBySerial` function in `pkg/driver/node.go` uses a regex that only matches SCSI-style disk symlinks in `/dev/disk/by-id/`:

```
scsi-0QEMU_HARDDISK_<serial>  →  matched by: QEMU_HARDDISK_([0-9a-f\-]+)
```

On **Virtuozzo 7** (and other hypervisors using **virtio-blk** instead of SCSI), disks appear with a different naming convention:

```
virtio-<serial>  →  NOT matched by the old regex
```

This causes `NodeStageVolume` to loop indefinitely with the log message:
```
Waiting for device with serial <uuid> to become available on host
```

The block device is present on the node (e.g. `/dev/vdb`), and the symlink exists in `/dev/disk/by-id/` (e.g. `virtio-a64f9d26-1e79-40a7-9`), but the CSI driver never finds it because the regex doesn't match the `virtio-` prefix.

### Additional context: Virtio serial truncation

The virtio-blk serial field is limited to **20 characters** by QEMU, so a full UUID like `a64f9d26-1e79-40a7-9964-e8865ef9adb2` appears truncated as `a64f9d26-1e79-40a7-9` in `/dev/disk/by-id/`. The existing prefix-match logic (`strings.Index(serial, uuid) == 0`) already handles this correctly — no changes needed there.

### Impact

After a node rebuild on a Virtuozzo 7 cluster, **no CSI volumes can be mounted**. All pods using PersistentVolumeClaims get stuck in `ContainerCreating` with `FailedMount` events.

## Fix

Extend the regex to match both naming conventions:

```go
// Before:
regex := regexp.MustCompile("QEMU_HARDDISK_([0-9a-f\\-]+)")

// After:
regex := regexp.MustCompile("(?:QEMU_HARDDISK[-_]|virtio-)([0-9a-f][-0-9a-f]*)")
```

This matches:
- `scsi-0QEMU_HARDDISK_<serial>` (SCSI/IDE — existing behavior preserved)
- `virtio-<serial>` (virtio-blk — new)

## Backward compatibility

The fix is fully backward compatible with SCSI controllers that pass the full UUID:

| Scenario | Symlink | Regex extracts | API serial | Match |
|----------|---------|---------------|------------|-------|
| **SCSI, full UUID** | `scsi-0QEMU_HARDDISK_a64f9d26-...-adb2` | `a64f9d26-...-adb2` | `a64f9d26-...-adb2` | ✅ exact match |
| **Virtio, truncated UUID** | `virtio-a64f9d26-1e79-40a7-9` | `a64f9d26-1e79-40a7-9` | `a64f9d26-...-adb2` | ✅ prefix match |
| **Virtio, full UUID** | `virtio-a64f9d26-...-adb2` | `a64f9d26-...-adb2` | `a64f9d26-...-adb2` | ✅ exact match |

The `strings.Index(serial, uuid) == 0` check verifies that the API serial **starts with** the extracted string. This works for both exact matches (full UUID) and prefix matches (truncated UUID).

## Tested

- Built and deployed as `flowswiss/csi-driver:v1.1.7` on an affected Virtuozzo 7 K3s cluster
- All previously stuck volumes mounted successfully within seconds after the rollout
- Verified via CSI driver logs: `Found matching device /dev/disk/by-id/virtio-<serial>`